### PR TITLE
Two Fixes

### DIFF
--- a/src/components/Utilities.js
+++ b/src/components/Utilities.js
@@ -27,27 +27,27 @@ export const taxBrackets = [
       {
         rate: 12,
         range: "$9,951 - $40,525",
-        amountInRange: 30574,
+        amountInRange: 30575,
       },
       {
         rate: 22,
         range: "$40,526 - $86,375",
-        amountInRange: 45849,
+        amountInRange: 45850,
       },
       {
         rate: 24,
         range: "$86,376 - $164,925",
-        amountInRange: 78549,
+        amountInRange: 78550,
       },
       {
         rate: 32,
         range: "$164,926 - $209,425",
-        amountInRange: 44499,
+        amountInRange: 44500,
       },
       {
         rate: 35,
         range: "$209,426 - $523,600",
-        amountInRange: 314174,
+        amountInRange: 314175,
       },
       {
         rate: 37,
@@ -68,27 +68,27 @@ export const taxBrackets = [
       {
         rate: 12,
         range: "$19,901 - $81,050",
-        amountInRange: 61149,
+        amountInRange: 61150,
       },
       {
         rate: 22,
         range: "$81,051 - $172,750",
-        amountInRange: 91699,
+        amountInRange: 91700,
       },
       {
         rate: 24,
         range: "$172,751 - $329,850",
-        amountInRange: 78549,
+        amountInRange: 78550,
       },
       {
         rate: 32,
         range: "$329,851 to $418,850",
-        amountInRange: 88999,
+        amountInRange: 89000,
       },
       {
         rate: 35,
         range: "$418,851 to $628,300",
-        amountInRange: 209499,
+        amountInRange: 209500,
       },
       {
         rate: 37,
@@ -109,27 +109,27 @@ export const taxBrackets = [
       {
         rate: 12,
         range: "$9,951 - $40,525",
-        amountInRange: 30574,
+        amountInRange: 30575,
       },
       {
         rate: 22,
         range: "$40,526 - $86,375",
-        amountInRange: 45849,
+        amountInRange: 45850,
       },
       {
         rate: 24,
         range: "$86,376 - $164,925",
-        amountInRange: 78549,
+        amountInRange: 78550,
       },
       {
         rate: 32,
         range: "$164,926 - $209,425",
-        amountInRange: 44499,
+        amountInRange: 44500,
       },
       {
         rate: 35,
         range: "$209,426 - $314,150",
-        amountInRange: 104724,
+        amountInRange: 104725,
       },
       {
         rate: 37,
@@ -150,27 +150,27 @@ export const taxBrackets = [
       {
         rate: 12,
         range: "$14,201 to $54,200",
-        amountInRange: 39999,
+        amountInRange: 40000,
       },
       {
         rate: 22,
         range: "$54,201 to $86,350",
-        amountInRange: 32149,
+        amountInRange: 32150,
       },
       {
         rate: 24,
         range: "$86,351 to $164,900",
-        amountInRange: 78549,
+        amountInRange: 78550,
       },
       {
         rate: 32,
         range: "$164,901 to $209,400",
-        amountInRange: 44499,
+        amountInRange: 44500,
       },
       {
         rate: 35,
         range: "$209,401 to $523,600",
-        amountInRange: 314199,
+        amountInRange: 314200,
       },
       {
         rate: 37,

--- a/src/components/Utilities.js
+++ b/src/components/Utilities.js
@@ -78,7 +78,7 @@ export const taxBrackets = [
       {
         rate: 24,
         range: "$172,751 - $329,850",
-        amountInRange: 78550,
+        amountInRange: 157100,
       },
       {
         rate: 32,


### PR DESCRIPTION
Futzing around with this, I found two issues, each fixed in a separate commit

1. although the _text_ in many tables is something like `$9,951 - $40,525`, the 1st dollar _is_ included in the bracket. We see this error accumulate when specifying a bracket-boundary value like `209425` with `Single`, where we expect all dollars to be under the `209425` cap of the 32% bracket, but $4 flow into the 35% bracket.
2. The `amountInRange` for the `married-bracket` with `rate: 24` is incorrect, likely a copy/paste issue. This causes money to "flow" into higher brackets prematurely.